### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ A comprehensive [Model Context Protocol (MCP)](https://modelcontextprotocol.io/)
 - **JWT authentication** with automatic token refresh and CSRF handling
 - **Streamable HTTP, SSE, and stdio transports**
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/bintocher-mcp-superset).
+
 ## Quick Start
 
 ### Installation


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/bintocher-mcp-superset).