### PR TITLE
fix: --version flag now derives from package version (#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.7] - 2026-06-15
+
+### Fixed
+
+- **`--version` reported a stale, hard-coded version.** The CLI banner was pinned to `0.2.4` in `__main__.py`, so `mcp-superset --version` printed the wrong version regardless of the installed package. It now derives the version from `mcp_superset.__version__`, keeping the CLI in sync with the package version automatically.
+
 ## [0.2.6] - 2026-06-09
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-superset"
-version = "0.2.6"
+version = "0.2.7"
 description = "MCP server for managing Apache Superset — dashboards, charts, datasets, SQL Lab, access control, and more"
 readme = "README.md"
 license = "MIT"

--- a/src/mcp_superset/__init__.py
+++ b/src/mcp_superset/__init__.py
@@ -1,3 +1,3 @@
 """MCP server for managing Apache Superset."""
 
-__version__ = "0.2.6"
+__version__ = "0.2.7"

--- a/src/mcp_superset/__main__.py
+++ b/src/mcp_superset/__main__.py
@@ -5,6 +5,8 @@ import os
 
 import uvicorn.config
 
+from mcp_superset import __version__
+
 # Override default uvicorn log config BEFORE importing FastMCP
 _date_format = "%Y-%m-%d %H:%M:%S"
 _log_format = "%(asctime)s.%(msecs)03d %(levelname)-5s %(message)s"
@@ -51,7 +53,7 @@ def main():
     parser.add_argument(
         "--version",
         action="version",
-        version="%(prog)s 0.2.4",
+        version=f"%(prog)s {__version__}",
     )
 
     args = parser.parse_args()

--- a/uv.lock
+++ b/uv.lock
@@ -679,7 +679,7 @@ wheels = [
 
 [[package]]
 name = "mcp-superset"
-version = "0.2.6"
+version = "0.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Closes #6.

The `--version` CLI flag was hard-coded to `0.2.4` in `src/mcp_superset/__main__.py`, so `mcp-superset --version` always printed a stale version regardless of the actually installed package (which was `0.2.6`).

## Changes

- `__main__.py`: import `__version__` from the package and pass `version=f"%(prog)s {__version__}"` to argparse, so the CLI banner stays in sync with the package version automatically (no more drift).
- Bumped version `0.2.6` -> `0.2.7` in `pyproject.toml` and `__init__.py` (single source of truth for `--version` now).
- Added CHANGELOG `[0.2.7]` entry.
- `uv.lock` updated to match the new version.

## Verification

```
$ uv run mcp-superset --version
mcp-superset 0.2.7
$ uv run python -m mcp_superset --version
mcp-superset 0.2.7
$ uv run python -c "import mcp_superset; print(mcp_superset.__version__)"
0.2.7
```

`ruff check src/` and `ruff format --check src/` both pass.