### PR TITLE
fix: preserve always_filter_main_dttm on dataset column updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ coverage.xml
 data/
 PROMOTION.md
 PROMOTION.md
+
+# Local MCP server run logs
+server.out.log
+server.err.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.8] - 2026-07-13
+
+### Fixed
+
+- **`superset_dataset_update` silently reset `always_filter_main_dttm` to false.** Superset's `PUT /dataset/{id}` drops the flag whenever it is omitted from the payload, so updating a dataset's `columns` (e.g. to set Russian `verbose_name` labels) turned off the main datetime filter and broke time filtering on every dependent dashboard. The tool now preserves the current value automatically when `columns` are replaced, and exposes a new optional `always_filter_main_dttm` parameter to set it explicitly.
+
 ## [0.2.7] - 2026-06-15
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-superset"
-version = "0.2.7"
+version = "0.2.8"
 description = "MCP server for managing Apache Superset — dashboards, charts, datasets, SQL Lab, access control, and more"
 readme = "README.md"
 license = "MIT"

--- a/src/mcp_superset/__init__.py
+++ b/src/mcp_superset/__init__.py
@@ -1,3 +1,3 @@
 """MCP server for managing Apache Superset."""
 
-__version__ = "0.2.7"
+__version__ = "0.2.8"

--- a/src/mcp_superset/tools/datasets.py
+++ b/src/mcp_superset/tools/datasets.py
@@ -95,6 +95,7 @@ def register_dataset_tools(mcp):
         columns: str | None = None,
         metrics: str | None = None,
         confirm_columns_replace: bool = False,
+        always_filter_main_dttm: bool | None = None,
     ) -> str:
         """Update a dataset. Only pass the fields you want to change.
 
@@ -111,6 +112,11 @@ def register_dataset_tools(mcp):
             metrics: JSON string describing metrics. Format:
                 [{"metric_name": "count", "expression": "COUNT(*)", "metric_type": "count"}]
             confirm_columns_replace: Confirmation for replacing ALL columns (REQUIRED when passing columns).
+            always_filter_main_dttm: Force the dataset's main datetime filter on/off.
+                Superset resets this flag to false on any PUT that omits it, which
+                breaks dashboard time filters when only columns/metrics are updated.
+                Pass an explicit value to set it; leave it None and the current
+                value is preserved automatically whenever columns are replaced.
 
         Returns:
             JSON string with the updated dataset details.
@@ -149,6 +155,18 @@ def register_dataset_tools(mcp):
             if err:
                 return json.dumps({"error": err}, ensure_ascii=False)
             payload["metrics"] = parsed
+        # Superset PUT /dataset/{id} resets always_filter_main_dttm to false when
+        # the field is omitted from the payload. Replacing columns without it then
+        # silently breaks the time filters on dependent dashboards. Use the explicit
+        # value when provided; otherwise, when columns are replaced, read and
+        # preserve the current value so the flag is not clobbered.
+        if always_filter_main_dttm is not None:
+            payload["always_filter_main_dttm"] = always_filter_main_dttm
+        elif columns is not None:
+            current = await client.get(f"/api/v1/dataset/{dataset_id}")
+            cur_val = (current.get("result") or {}).get("always_filter_main_dttm")
+            if cur_val is not None:
+                payload["always_filter_main_dttm"] = cur_val
         result = await client.put(f"/api/v1/dataset/{dataset_id}", json_data=payload)
         return json.dumps(result, ensure_ascii=False)
 


### PR DESCRIPTION
## Problem

Superset's `PUT /dataset/{id}` resets `always_filter_main_dttm` to `false` whenever the field is omitted from the payload. So calling `superset_dataset_update` with `columns` (e.g. to set Russian `verbose_name` labels) silently turned off the dataset's main datetime filter, breaking time filtering on every dependent dashboard.

## Fix

- `superset_dataset_update` now reads the current dataset and **preserves** `always_filter_main_dttm` automatically whenever `columns` are replaced.
- Adds an optional `always_filter_main_dttm` parameter to set the flag explicitly.

## Notes

- No behaviour change when `columns` are not passed.
- Version bumped to `0.2.8`, CHANGELOG updated.
- `ruff check` / `ruff format --check` pass; local server run logs added to `.gitignore`.