### PR TITLE
fix: null json_metadata and JSON-encoded list arguments (#11, #12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-07-25
+
+### Fixed
+
+- **Native filter tools crashed on dashboards whose `json_metadata` is null** (#11). Superset returns `json_metadata: null` (not `"{}"`) for dashboards that have never had metadata written, so `superset_dashboard_filter_add/list/update/delete/reset` raised `TypeError: the JSON object must be str, bytes or bytearray, not NoneType` before making any API call. Null `json_metadata` and `position_json` are now read as empty objects everywhere.
+- **List arguments were unusable when the client sent them JSON-encoded** (#12). Some MCP clients serialise `dashboards=[31]` as the string `"[31]"`, which pydantic rejected with `list_type`, so `superset_chart_update(dashboards=...)` never ran. All list parameters (`dashboards`, `roles`, `owners`, `users`, `user_ids`, `role_ids`, `tables`, `permission_view_menu_ids`, `allowed_domains`) now accept a native list, a JSON-encoded list, a bare value, or a comma-separated string.
+
+### Changed
+
+- Superset error responses of the form `{"errors": [{"message": ..., "error_type": ..., "extra": {"issue_codes": [...]}}]}` are now unpacked into the raised error instead of being stringified, so a 500 carries the error type and issue codes rather than a bare "Fatal error".
+
 ## [0.3.0] - 2026-07-25
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-superset"
-version = "0.3.0"
+version = "0.3.1"
 description = "MCP server for managing Apache Superset — dashboards, charts, datasets, SQL Lab, access control, and more"
 readme = "README.md"
 license = "MIT"

--- a/src/mcp_superset/__init__.py
+++ b/src/mcp_superset/__init__.py
@@ -1,3 +1,3 @@
 """MCP server for managing Apache Superset."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/src/mcp_superset/client.py
+++ b/src/mcp_superset/client.py
@@ -64,13 +64,50 @@ class SupersetClient:
         """
         try:
             error_body = resp.json()
-            detail = error_body.get("message", "") or error_body.get("errors", str(error_body))
+            detail = error_body.get("message", "") or self._format_errors(error_body.get("errors")) or str(error_body)
         except Exception:
             detail = resp.text[:500]
         detail = str(detail)
         if resp.status_code == 401 and self.auth.auth_failure_hint:
             detail = " - ".join(p for p in (detail, self.auth.auth_failure_hint) if p)
         return detail
+
+    @staticmethod
+    def _format_errors(errors: Any) -> str:
+        """Flatten Superset's errors payload into a readable line.
+
+        Superset returns 500s as {"errors": [{"message": "Fatal error",
+        "error_type": ..., "extra": {"issue_codes": [{"code": N, ...}]}}]},
+        which is far more useful than the bare "Fatal error" once unpacked.
+
+        Args:
+            errors: The "errors" value from a Superset error response.
+
+        Returns:
+            A single-line summary, or "" when there is nothing to unpack.
+        """
+        if not errors:
+            return ""
+        if not isinstance(errors, list):
+            return str(errors)
+        parts = []
+        for item in errors:
+            if not isinstance(item, dict):
+                parts.append(str(item))
+                continue
+            text = str(item.get("message", "")).strip()
+            error_type = item.get("error_type")
+            if error_type:
+                text = f"{text} [{error_type}]" if text else f"[{error_type}]"
+            extra = item.get("extra") or {}
+            codes = extra.get("issue_codes") if isinstance(extra, dict) else None
+            if isinstance(codes, list):
+                messages = [str(c.get("message", "")).strip() for c in codes if isinstance(c, dict)]
+                messages = [m for m in messages if m]
+                if messages:
+                    text = f"{text} ({'; '.join(messages)})"
+            parts.append(text or str(item))
+        return " | ".join(p for p in parts if p)
 
     async def _request(
         self,

--- a/src/mcp_superset/tools/charts.py
+++ b/src/mcp_superset/tools/charts.py
@@ -5,6 +5,7 @@ import json
 import re
 
 from mcp_superset.tools.helpers import auto_sync_chart_dashboards, parse_json_arg
+from mcp_superset.tools.types import IntList
 
 # Moment.js date format patterns that do NOT work in Superset 6.x.
 # Superset uses D3 strftime (%Y-%m-%d); moment.js (YYYY-MM-DD) renders as literal text.
@@ -353,7 +354,7 @@ def register_chart_tools(mcp):
         datasource_type: str = "table",
         params: str | None = None,
         query_context: str | None = None,
-        dashboards: list[int] | None = None,
+        dashboards: IntList | None = None,
     ) -> str:
         """Create a new chart.
 
@@ -503,7 +504,7 @@ def register_chart_tools(mcp):
         viz_type: str | None = None,
         params: str | None = None,
         query_context: str | None = None,
-        dashboards: list[int] | None = None,
+        dashboards: IntList | None = None,
         confirm_params_replace: bool = False,
     ) -> str:
         """Update an existing chart. Pass only the fields to change.
@@ -702,7 +703,7 @@ def register_chart_tools(mcp):
     async def superset_chart_copy(
         chart_id: int,
         slice_name: str,
-        dashboards: list[int] | None = None,
+        dashboards: IntList | None = None,
     ) -> str:
         """Create a copy of an existing chart with a new name.
 

--- a/src/mcp_superset/tools/dashboards.py
+++ b/src/mcp_superset/tools/dashboards.py
@@ -5,6 +5,7 @@ import json
 import uuid
 
 from mcp_superset.tools.helpers import parse_json_arg
+from mcp_superset.tools.types import IntList, StrList
 
 KPI_VIZ_TYPES = {"big_number_total", "big_number"}
 MIN_KPI_HEIGHT = 16  # 2 grid cells (1 cell = 8 units)
@@ -291,7 +292,7 @@ def register_dashboard_tools(mcp):
         json_metadata: str | None = None,
         css: str | None = None,
         position_json: str | None = None,
-        roles: list[int] | None = None,
+        roles: IntList | None = None,
     ) -> str:
         """Create a new dashboard.
 
@@ -364,8 +365,8 @@ def register_dashboard_tools(mcp):
         json_metadata: str | dict | None = None,
         css: str | None = None,
         position_json: str | dict | None = None,
-        owners: list[int] | None = None,
-        roles: list[int] | None = None,
+        owners: IntList | None = None,
+        roles: IntList | None = None,
     ) -> str:
         """Update an existing dashboard. Pass only the fields to change.
 
@@ -658,7 +659,7 @@ def register_dashboard_tools(mcp):
     @mcp.tool
     async def superset_dashboard_embedded_set(
         dashboard_id: int,
-        allowed_domains: list[str] | None = None,
+        allowed_domains: StrList | None = None,
     ) -> str:
         """Enable dashboard embedding (embedded mode) and configure allowed domains.
 
@@ -708,7 +709,7 @@ def register_dashboard_tools(mcp):
         """
         dashboard = await client.get(f"/api/v1/dashboard/{dashboard_id}")
         result = dashboard.get("result", {})
-        metadata = json.loads(result.get("json_metadata", "{}"))
+        metadata = json.loads(result.get("json_metadata") or "{}")
         filters = metadata.get("native_filter_configuration", [])
         summary = []
         for f in filters:
@@ -764,8 +765,8 @@ def register_dashboard_tools(mcp):
         """
         dashboard = await client.get(f"/api/v1/dashboard/{dashboard_id}")
         result = dashboard.get("result", {})
-        metadata = json.loads(result.get("json_metadata", "{}"))
-        position = json.loads(result.get("position_json", "{}"))
+        metadata = json.loads(result.get("json_metadata") or "{}")
+        position = json.loads(result.get("position_json") or "{}")
 
         chart_ids = _extract_chart_ids(position)
         filter_id = f"NATIVE_FILTER-{uuid.uuid4()}"
@@ -854,7 +855,7 @@ def register_dashboard_tools(mcp):
         """
         dashboard = await client.get(f"/api/v1/dashboard/{dashboard_id}")
         result = dashboard.get("result", {})
-        metadata = json.loads(result.get("json_metadata", "{}"))
+        metadata = json.loads(result.get("json_metadata") or "{}")
         filters = metadata.get("native_filter_configuration", [])
 
         target = None
@@ -908,7 +909,7 @@ def register_dashboard_tools(mcp):
         """
         dashboard = await client.get(f"/api/v1/dashboard/{dashboard_id}")
         result = dashboard.get("result", {})
-        metadata = json.loads(result.get("json_metadata", "{}"))
+        metadata = json.loads(result.get("json_metadata") or "{}")
         filters = metadata.get("native_filter_configuration", [])
 
         target = None
@@ -982,7 +983,7 @@ def register_dashboard_tools(mcp):
             # Show current filters for an informed decision
             dashboard = await client.get(f"/api/v1/dashboard/{dashboard_id}")
             result = dashboard.get("result", {})
-            metadata = json.loads(result.get("json_metadata", "{}"))
+            metadata = json.loads(result.get("json_metadata") or "{}")
             current_filters = metadata.get("native_filter_configuration", [])
             current_names = [f.get("name", "?") for f in current_filters]
             return json.dumps(
@@ -998,8 +999,8 @@ def register_dashboard_tools(mcp):
 
         dashboard = await client.get(f"/api/v1/dashboard/{dashboard_id}")
         result = dashboard.get("result", {})
-        metadata = json.loads(result.get("json_metadata", "{}"))
-        position = json.loads(result.get("position_json", "{}"))
+        metadata = json.loads(result.get("json_metadata") or "{}")
+        position = json.loads(result.get("position_json") or "{}")
 
         chart_ids = _extract_chart_ids(position)
         filter_defs, err = parse_json_arg(filters_json, "filters_json")

--- a/src/mcp_superset/tools/groups.py
+++ b/src/mcp_superset/tools/groups.py
@@ -2,6 +2,8 @@
 
 import json
 
+from mcp_superset.tools.types import IntList
+
 
 def register_group_tools(mcp):
     """Register all group management tools with the MCP server."""
@@ -54,8 +56,8 @@ def register_group_tools(mcp):
         name: str,
         label: str | None = None,
         description: str | None = None,
-        roles: list[int] | None = None,
-        users: list[int] | None = None,
+        roles: IntList | None = None,
+        users: IntList | None = None,
     ) -> str:
         """Create a new user group.
 
@@ -104,8 +106,8 @@ def register_group_tools(mcp):
         name: str | None = None,
         label: str | None = None,
         description: str | None = None,
-        roles: list[int] | None = None,
-        users: list[int] | None = None,
+        roles: IntList | None = None,
+        users: IntList | None = None,
         confirm_roles_replace: bool = False,
         confirm_users_replace: bool = False,
     ) -> str:
@@ -229,7 +231,7 @@ def register_group_tools(mcp):
     @mcp.tool
     async def superset_group_add_users(
         group_id: int,
-        user_ids: list[int],
+        user_ids: IntList,
     ) -> str:
         """Add users to a group without removing existing ones.
 
@@ -267,7 +269,7 @@ def register_group_tools(mcp):
     @mcp.tool
     async def superset_group_remove_users(
         group_id: int,
-        user_ids: list[int],
+        user_ids: IntList,
     ) -> str:
         """Remove users from a group without removing the rest.
 
@@ -302,7 +304,7 @@ def register_group_tools(mcp):
     @mcp.tool
     async def superset_group_add_roles(
         group_id: int,
-        role_ids: list[int],
+        role_ids: IntList,
     ) -> str:
         """Add roles to a group without removing existing ones.
 
@@ -337,7 +339,7 @@ def register_group_tools(mcp):
     @mcp.tool
     async def superset_group_remove_roles(
         group_id: int,
-        role_ids: list[int],
+        role_ids: IntList,
     ) -> str:
         """Remove roles from a group without removing the rest.
 

--- a/src/mcp_superset/tools/security.py
+++ b/src/mcp_superset/tools/security.py
@@ -3,6 +3,7 @@
 import json
 
 from mcp_superset.tools.helpers import find_datasource_permissions
+from mcp_superset.tools.types import IntList
 
 
 def register_security_tools(mcp):
@@ -79,7 +80,7 @@ def register_security_tools(mcp):
         username: str,
         email: str,
         password: str,
-        roles: list[int] | None = None,
+        roles: IntList | None = None,
         active: bool = True,
     ) -> str:
         """Create a new Superset user.
@@ -113,7 +114,7 @@ def register_security_tools(mcp):
         first_name: str | None = None,
         last_name: str | None = None,
         email: str | None = None,
-        roles: list[int] | None = None,
+        roles: IntList | None = None,
         active: bool | None = None,
         confirm_roles_replace: bool = False,
     ) -> str:
@@ -394,7 +395,7 @@ def register_security_tools(mcp):
     @mcp.tool
     async def superset_role_permission_add(
         role_id: int,
-        permission_view_menu_ids: list[int],
+        permission_view_menu_ids: IntList,
         confirm_full_replace: bool = False,
     ) -> str:
         """Set the permissions list for a role (FULL REPLACEMENT).
@@ -811,8 +812,8 @@ def register_security_tools(mcp):
     async def superset_rls_create(
         name: str,
         clause: str,
-        tables: list[int],
-        roles: list[int],
+        tables: IntList,
+        roles: IntList,
         filter_type: str = "Regular",
         group_key: str | None = None,
         description: str | None = None,
@@ -871,8 +872,8 @@ def register_security_tools(mcp):
         name: str | None = None,
         filter_type: str | None = None,
         clause: str | None = None,
-        tables: list[int] | None = None,
-        roles: list[int] | None = None,
+        tables: IntList | None = None,
+        roles: IntList | None = None,
         group_key: str | None = None,
         description: str | None = None,
     ) -> str:
@@ -976,7 +977,7 @@ def register_security_tools(mcp):
     @mcp.tool
     async def superset_bulk_user_role_add(
         role_id: int,
-        user_ids: list[int] | None = None,
+        user_ids: IntList | None = None,
         filter_role_id: int | None = None,
         exclude_admin: bool = True,
         confirm: bool = False,
@@ -1059,7 +1060,7 @@ def register_security_tools(mcp):
     @mcp.tool
     async def superset_bulk_user_role_remove(
         role_id: int,
-        user_ids: list[int] | None = None,
+        user_ids: IntList | None = None,
         exclude_admin: bool = True,
         confirm: bool = False,
     ) -> str:

--- a/src/mcp_superset/tools/types.py
+++ b/src/mcp_superset/tools/types.py
@@ -1,0 +1,39 @@
+"""Argument types for tools, tolerant of how MCP clients encode lists.
+
+Several MCP clients serialise array arguments as a JSON string before the call
+reaches pydantic, so `dashboards=[31]` arrives as the string `"[31]"` and a
+plain `list[int]` annotation rejects it with a validation error. These aliases
+accept both the native list and its JSON-encoded form.
+"""
+
+import json
+from typing import Annotated, Any
+
+from pydantic import BeforeValidator
+
+
+def coerce_list(value: Any) -> Any:
+    """Turn a JSON-encoded (or comma-separated) list into a real list.
+
+    Args:
+        value: Raw argument value as received from the MCP client.
+
+    Returns:
+        A list when the input was a string encoding one, otherwise the value
+        unchanged - pydantic then validates the item types as usual.
+    """
+    if not isinstance(value, str):
+        return value
+    text = value.strip()
+    if not text:
+        return []
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        # Tolerate "31,32" as well - some clients flatten arrays that way.
+        return [part.strip() for part in text.split(",") if part.strip()]
+    return parsed if isinstance(parsed, list) else [parsed]
+
+
+IntList = Annotated[list[int], BeforeValidator(coerce_list)]
+StrList = Annotated[list[str], BeforeValidator(coerce_list)]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,8 @@
 """Shared pytest fixtures for mcp-superset tests."""
+
+import os
+
+# mcp_superset.server builds its auth strategy at import time, so tests that
+# import it need a configuration present before that import happens.
+os.environ.setdefault("SUPERSET_BASE_URL", "https://superset.example.com")
+os.environ.setdefault("SUPERSET_SESSION_COOKIE", "test-cookie")

--- a/tests/test_tool_arguments.py
+++ b/tests/test_tool_arguments.py
@@ -1,0 +1,48 @@
+"""Tests for tool argument coercion (issue #12) and null-metadata handling (issue #11)."""
+
+import json
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from mcp_superset.tools.types import IntList, StrList
+
+INT_LIST = TypeAdapter(IntList)
+STR_LIST = TypeAdapter(StrList)
+
+
+def test_json_encoded_int_list_is_accepted():
+    """Some MCP clients send [31] as the string "[31]"."""
+    assert INT_LIST.validate_python("[31]") == [31]
+
+
+def test_native_int_list_still_works():
+    assert INT_LIST.validate_python([31, 32]) == [31, 32]
+
+
+def test_single_value_string_becomes_a_list():
+    assert INT_LIST.validate_python("31") == [31]
+
+
+def test_comma_separated_string_is_accepted():
+    assert INT_LIST.validate_python("31, 32") == [31, 32]
+
+
+def test_empty_string_is_an_empty_list():
+    assert INT_LIST.validate_python("") == []
+
+
+def test_str_list_json_encoded():
+    assert STR_LIST.validate_python('["a", "b"]') == ["a", "b"]
+
+
+def test_non_numeric_items_still_rejected():
+    with pytest.raises(ValidationError):
+        INT_LIST.validate_python('["not-an-int"]')
+
+
+def test_null_json_metadata_is_treated_as_empty():
+    """Superset returns json_metadata: null for freshly created dashboards."""
+    result = {"json_metadata": None, "position_json": None}
+    assert json.loads(result.get("json_metadata") or "{}") == {}
+    assert json.loads(result.get("position_json") or "{}") == {}

--- a/tests/test_tools_end_to_end.py
+++ b/tests/test_tools_end_to_end.py
@@ -1,0 +1,87 @@
+"""End-to-end tool tests over the MCP layer, covering the reported bugs.
+
+Issue #11: dashboards whose json_metadata is null crashed every native-filter
+tool with a TypeError before any API call was made.
+Issue #12: list arguments arrive JSON-encoded from some clients ("[31]"), which
+pydantic rejected, making the dashboards parameter unusable.
+"""
+
+import json
+
+import httpx
+import pytest
+import respx
+from fastmcp import Client, FastMCP
+
+import mcp_superset.server as server_module
+from mcp_superset.auth import CookieAuthManager
+from mcp_superset.client import SupersetClient
+from mcp_superset.tools import register_all_tools
+
+BASE = "https://superset.example.com"
+
+
+@pytest.fixture
+def mcp_server(monkeypatch):
+    """An MCP server whose tools talk to a SupersetClient we can mock with respx."""
+    client = SupersetClient(auth_manager=CookieAuthManager(base_url=BASE, cookie_value="c"), base_url=BASE)
+    monkeypatch.setattr(server_module, "superset_client", client)
+    mcp = FastMCP(name="test")
+    register_all_tools(mcp)
+    yield mcp
+
+
+def _text(result):
+    """Extract the tool's text payload across fastmcp result shapes."""
+    content = getattr(result, "content", result)
+    if isinstance(content, list) and content:
+        return content[0].text
+    return str(content)
+
+
+@respx.mock
+async def test_filter_list_on_dashboard_with_null_metadata(mcp_server):
+    respx.get(f"{BASE}/api/v1/dashboard/31").mock(
+        return_value=httpx.Response(200, json={"result": {"id": 31, "json_metadata": None, "position_json": None}})
+    )
+    async with Client(mcp_server) as c:
+        result = await c.call_tool("superset_dashboard_filter_list", {"dashboard_id": 31})
+
+    assert json.loads(_text(result)) == []
+
+
+@respx.mock
+async def test_filter_add_on_dashboard_with_null_metadata(mcp_server):
+    respx.get(f"{BASE}/api/v1/dashboard/31").mock(
+        return_value=httpx.Response(200, json={"result": {"id": 31, "json_metadata": None, "position_json": None}})
+    )
+    respx.get(f"{BASE}/api/v1/security/csrf_token/").mock(return_value=httpx.Response(200, json={"result": "csrf"}))
+    put = respx.put(f"{BASE}/api/v1/dashboard/31").mock(return_value=httpx.Response(200, json={"result": {}}))
+    respx.get(f"{BASE}/api/v1/dashboard/31/datasets").mock(return_value=httpx.Response(200, json={"result": []}))
+    respx.get(f"{BASE}/api/v1/dashboard/31/charts").mock(return_value=httpx.Response(200, json={"result": []}))
+
+    async with Client(mcp_server) as c:
+        result = await c.call_tool(
+            "superset_dashboard_filter_add",
+            {"dashboard_id": 31, "name": "Region", "column": "region", "dataset_id": 7},
+        )
+
+    payload = json.loads(_text(result))
+    assert payload["status"] == "ok"
+    assert payload["filter_id"].startswith("NATIVE_FILTER-")
+    sent = json.loads(json.loads(put.calls.last.request.content)["json_metadata"])
+    assert len(sent["native_filter_configuration"]) == 1
+
+
+@respx.mock
+async def test_chart_update_accepts_json_encoded_dashboards(mcp_server):
+    respx.get(f"{BASE}/api/v1/security/csrf_token/").mock(return_value=httpx.Response(200, json={"result": "csrf"}))
+    put = respx.put(f"{BASE}/api/v1/chart/65").mock(return_value=httpx.Response(200, json={"result": {"id": 65}}))
+    respx.get(f"{BASE}/api/v1/chart/65").mock(
+        return_value=httpx.Response(200, json={"result": {"id": 65, "dashboards": [], "datasource_id": 7}})
+    )
+
+    async with Client(mcp_server) as c:
+        await c.call_tool("superset_chart_update", {"chart_id": 65, "dashboards": "[31]"})
+
+    assert json.loads(put.calls.last.request.content)["dashboards"] == [31]

--- a/uv.lock
+++ b/uv.lock
@@ -688,7 +688,7 @@ wheels = [
 
 [[package]]
 name = "mcp-superset"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Summary

Fixes two reported bugs, both reproduced against Superset 6.0.1.

## Changes

- **#11** - Superset returns `json_metadata: null` (not `"{}"`) for dashboards that never had metadata written, so `superset_dashboard_filter_add/list/update/delete/reset` raised `TypeError: the JSON object must be str, bytes or bytearray, not NoneType` before any API call. Null `json_metadata` and `position_json` are now read as empty objects.
- **#12** - some MCP clients serialise list arguments as JSON strings, so `dashboards=[31]` arrives as `"[31]"` and pydantic rejects it with `list_type`. All list parameters now use `IntList`/`StrList`, which accept a native list, a JSON-encoded list, a bare value, or a comma-separated string.
- Superset's `{"errors": [...]}` payload is unpacked into the raised error, so a 500 carries `error_type` and issue codes instead of a bare "Fatal error". This is groundwork for diagnosing #13, which does not reproduce here.

## Related Issues

Closes #11
Closes #12

## Checklist

- [x] Code follows the project's style guidelines (`ruff check` passes)
- [x] Code is formatted (`ruff format` passes)
- [x] Self-review completed
- [x] Documentation updated (if applicable)
- [x] No credentials or secrets included

Tests run over the MCP layer (fastmcp in-memory client + respx) and fail on the previous code; 32 tests pass in total. Verified end-to-end against a live Superset 6.0.1 instance.